### PR TITLE
compie livescript with bare option on

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -112,7 +112,7 @@ compilers =
     ext: ['ls']
     compile: (path, filename, source, str, plunk, fn) ->
       try
-        fn(null, livescript.compile(str))
+        fn(null, livescript.compile(str, {bare: true}))
       catch err
         fn(err)      
       


### PR DESCRIPTION
Note that script.ls in http://plnkr.co/edit/23cfehsiW1Mt0ivjQy8g?p=info requires `d3 = window.d3`, since livescript code wasn't compiled with `{bare: true}`
